### PR TITLE
Include breadcrumb navigation

### DIFF
--- a/templates/frontend/pages/section.tpl
+++ b/templates/frontend/pages/section.tpl
@@ -20,7 +20,7 @@
  *}
 
 {include file="frontend/components/header.tpl" pageTitleTranslated=$section->getLocalizedTitle()|escape}
-
+{include file="frontend/components/breadcrumbs.tpl" currentTitle=$section->getLocalizedTitle()|escape}
 <div class="page page_section page_section_{$sectionPath|escape}">
 	<h1 class="page_title">
 		{$section->getLocalizedTitle()|escape}


### PR DESCRIPTION
Include the breadcrumb navigation. Otherwise the space between the headline and the header is too narrow